### PR TITLE
Fix multiaxis file tracking bugs and Python 3.12+ compatibility

### DIFF
--- a/CsmakeCore/CliDriver.py
+++ b/CsmakeCore/CliDriver.py
@@ -20,8 +20,27 @@ import atexit
 import traceback
 try:
     import imp
-except:
-    import importlib as imp
+except ImportError:
+    # imp was removed in Python 3.12; provide a shim for the three entry points
+    # used below: acquire_lock, release_lock, and load_source.
+    import threading as _threading
+    import importlib.util as _importlib_util
+
+    class _ImpShim(object):
+        def __init__(self):
+            self._lock = _threading.RLock()
+        def acquire_lock(self):
+            self._lock.acquire()
+        def release_lock(self):
+            self._lock.release()
+        def load_source(self, name, path):
+            spec = _importlib_util.spec_from_file_location(name, path)
+            module = _importlib_util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)
+            return module
+
+    imp = _ImpShim()
 import pkgutil
 import types
 import time

--- a/CsmakeCore/FileManager.py
+++ b/CsmakeCore/FileManager.py
@@ -171,7 +171,7 @@ class IndexedFileEntry:
         if self.currentPrecedenceKey is None:
             raise ValueError("setCurrentPrecedenceKey must be called first")
         return self.getPrecedence(self.currentPrecedenceKey) \
-               == other.getPrecedence(self.currentPreceedenceKey)
+               == other.getPrecedence(self.currentPrecedenceKey)
 
     def __lt__(self, other):
         if self.currentPrecedenceKey is None:
@@ -182,7 +182,7 @@ class IndexedFileEntry:
     def __gt__(self, other):
         if self.currentPrecedenceKey is None:
             raise ValueError("setCurrentPrecedenceKey must be called first")
-        return self.getRecedence(self.currentPrecedenceKey) \
+        return self.getPrecedence(self.currentPrecedenceKey) \
                 > other.getPrecedence(self.currentPrecedenceKey)
 
     def __hash__(self):
@@ -1141,12 +1141,7 @@ class FileManager:
             for key, value in ato.index.items():
                 if '[~~' in value:
                     continue
-                if key not in specCollection:
-                    specCollection[key] = value
-                if specCollection[key] != value or type(value) is list:
-                    specCollection[key] = value
-                else:
-                    specCollection[key] = {'values': [value, specCollection[key]]}
+                specCollection[key] = value
         for ato in tos:
             for locKey in ['location', 'relLocation']:
                 if locKey in ato.index:

--- a/CsmakeCore/tests/FileManager/testFileManager_basic.py
+++ b/CsmakeCore/tests/FileManager/testFileManager_basic.py
@@ -223,6 +223,41 @@ class testFileManager_basic(unittest.TestCase):
         #Test string rep of FileMapper
         str(cut)
 
+    def test_manyToOneSubstitutionWithMatchingToSpecKeyValue(self):
+        # Bug regression: when all froms agree on a key value and the to-spec
+        # carries the SAME value for that key, [~~key~~] in the output path
+        # should resolve successfully.  The old else-branch in
+        # _fromManyMapSubstitutions was creating a spurious conflict dict on
+        # equal values, which caused a false IndeterminateSubstitution error.
+        cut = self._createaCUT()
+        cut.addFileDeclaration("<myid(test:testing)> *.ext")
+        # to-spec has type='test' — same as every from; path uses [~~type~~]
+        result = cut.parseFileMap(
+            "<(test:testing)> -(*-1)-> <(test:output)> [~~type~~]_output.lib")
+        for froms, tos in result.iterspecs():
+            self.assertEqual(tos[0]['relLocation'], 'test_output.lib')
+
+    def test_manyToOneSubstitutionConflictUnresolvedByToSpecRaisesError(self):
+        # When froms conflict on a substitution key and the to-spec provides no
+        # resolution for it, IndeterminateSubstitution must still be raised.
+        cut = self._createaCUT()
+        cut.addFileDeclaration("<myid(test:testing)> test_*.ext")
+        cut.addFileDeclaration("<otherid(other:testing)> other_*.ext")
+        with self.assertRaises(ValueError):
+            cut.parseFileMap("*.ext -(*-1)-> [~~type~~]_output.lib")
+
+    def test_manyToOneSubstitutionConflictResolvedByToSpec(self):
+        # When froms conflict on a key but the to-spec supplies a definitive
+        # non-substitution value for that same key, the to-spec value should
+        # resolve the conflict and substitution should succeed.
+        cut = self._createaCUT()
+        cut.addFileDeclaration("<myid(test:testing)> test_*.ext")
+        cut.addFileDeclaration("<otherid(other:testing)> other_*.ext")
+        result = cut.parseFileMap(
+            "*.ext -(*-1)-> <(lib:output)> [~~type~~]_output.lib")
+        for froms, tos in result.iterspecs():
+            self.assertEqual(tos[0]['relLocation'], 'lib_output.lib')
+
     def test_reFileDeclaration(self):
         cut = self._createaCUT()
         result = cut.addFileDeclaration("<myid (test:testing)> ~~test_[^.1][.]ext")

--- a/RUNTESTS.sh
+++ b/RUNTESTS.sh
@@ -244,6 +244,11 @@ dotest file-before-metadata test-filetracking.csmake file-before-metadata build
 dotest-cmp files-kept-thru-metadata test-filetracking.csmake files-kept-thru-metadata build "RUNTESTS.sh"
 dotest-cmp ensure-files-not-kept-thru-metadata test-filetracking.csmake ensure-files-not-kept-thru-metadata build ""
 
+#Test *-1 map substitution - froms and to-spec agree on the substituted key value
+dotest manytoone-type-agrees test-manytoone-substitution.csmake test-manytoone-type-agrees build
+#Test *-1 map substitution - to-spec resolves a type conflict from froms
+dotest manytoone-conflict-resolved test-manytoone-substitution.csmake test-manytoone-conflict-resolved build
+
 #Test TestPython
 dotest-default test-TestPython test-TestPython.csmake
 dotest-fail test-TestPython-failure test-TestPython.csmake show-failure test

--- a/test-manytoone-substitution.csmake
+++ b/test-manytoone-substitution.csmake
@@ -1,0 +1,78 @@
+# <copyright>
+# (c) Copyright 2026 Autumn Patterson
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# </copyright>
+
+[metadata@test-manytoone-substitution]
+name=test-manytoone-substitution
+version=0.0.0
+description=Spec tests for *-1 map substitution correctness
+
+# Create two real source files so the tracker can validate and register them.
+[Shell@create-agreeing-source-files]
+**yields-files=<srcs (c-source:compile)> fake_a.c
+    <srcs (c-source:compile)> fake_b.c
+command=touch %(RESULTS)s/fake_a.c %(RESULTS)s/fake_b.c
+
+# Bug regression: the to-spec carries type='c-source' — the same value every
+# from already has.  [~~type~~] in the output path should resolve to 'c-source'.
+# The bug in _fromManyMapSubstitutions caused a spurious IndeterminateSubstitution
+# error here because the else-branch created a conflict dict on two equal values.
+[Shell@map-agreeing-type-many-to-one]
+**maps=<srcs (c-source:compile)> -(*-1)-> <srcs (c-source:library)> [~~type~~]_output.a
+command=for map in $_MAPPING
+    do
+        for to in $(_tos $map)
+        do
+            touch $to
+        done
+    done
+
+[Shell@cleanup-agreeing]
+command=rm -f %(RESULTS)s/fake_a.c %(RESULTS)s/fake_b.c %(RESULTS)s/c-source_output.a
+
+[command@test-manytoone-type-agrees]
+description=*-1 map where froms and to-spec agree on the substituted key value
+000=create-agreeing-source-files
+001=map-agreeing-type-many-to-one
+002=cleanup-agreeing
+
+
+# Create two files with DIFFERENT types to produce a real conflict in the tracker.
+[Shell@create-mixed-source-files]
+**yields-files=<mixed (c-source:compile)> mixed_a.c
+    <mixed (c-header:compile)> mixed_b.h
+command=touch %(RESULTS)s/mixed_a.c %(RESULTS)s/mixed_b.h
+
+# The to-spec provides type='elf-object', resolving the conflict.
+# [~~type~~] should resolve to 'elf-object', not raise IndeterminateSubstitution.
+[Shell@map-conflict-resolved-by-to-spec]
+**maps=<mixed> -(*-1)-> <mixed (elf-object:library)> [~~type~~]_output.a
+command=for map in $_MAPPING
+    do
+        for to in $(_tos $map)
+        do
+            touch $to
+        done
+    done
+
+[Shell@cleanup-mixed]
+command=rm -f %(RESULTS)s/mixed_a.c %(RESULTS)s/mixed_b.h %(RESULTS)s/elf-object_output.a
+
+[command@test-manytoone-conflict-resolved]
+description=*-1 map where to-spec resolves a type conflict from froms
+000=create-mixed-source-files
+001=map-conflict-resolved-by-to-spec
+002=cleanup-mixed


### PR DESCRIPTION
FileManager.py — three bugs in the multiaxis file typing system:
- Fix typo `currentPreceedenceKey` in IndexedFileEntry.__eq__ (AttributeError at runtime on any sort/equality check involving file entries)
- Fix typo `getRecedence` in IndexedFileEntry.__gt__ (AttributeError on > comparisons)
- Fix inverted logic in _fromManyMapSubstitutions tos loop: the old else-branch created a spurious conflict dict when froms and to-spec agreed on a key value, causing a false IndeterminateSubstitution error on valid *-1 and *-* maps. To-spec values now always win (resolving any froms conflict), matching the intended semantics that the to-spec is authoritative about output file axes.

CliDriver.py — Python 3.12 removed the imp module entirely; the previous fallback `import importlib as imp` provided no acquire_lock, release_lock, or load_source, so the module loader crashed on startup. Replace with a proper duck-typed shim (_ImpShim) backed by threading.RLock and importlib.util.spec_from_file_location so all Python versions work.

Tests — three new unit tests pinning the *-1 substitution correctness, plus a new spec test file (test-manytoone-substitution.csmake) with two end-to-end scenarios wired into RUNTESTS.sh.